### PR TITLE
Disable smartypants

### DIFF
--- a/frontend/js/utils/ChatMessage.js
+++ b/frontend/js/utils/ChatMessage.js
@@ -60,7 +60,6 @@ marked.setOptions({
   pedantic: false,
   sanitize: true,
   smartLists: true,
-  smartypants: true,
   highlight: function (code, lang) {
     var ret = '';
     try {


### PR DESCRIPTION
Smartypants causes. among other things, the conversion of apostrophes `'` (`U+0027`) to left/right single quotation marks `‘`/`’` (`U+2018`/`U+2019`) and makes copy-pasting code from chat to WindBot an issue. Example:

```
auto(100) if killCount,get('Dark Torturer') > 0 then xlog() end
```

becomes:

```
auto(100) if killCount,get(‘Dark Torturer’) > 0 then xlog() end
```

(Notice the difference on the apostrophes)
